### PR TITLE
fix: pin dependency versions in requirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+flake8==7.0.0
+black==24.4.2
+isort==5.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,11 @@
-crewai[tools]
-playwright
-pytest
-pytest-html
-pytest-json-report
-pytest-xdist
-python-dotenv
-rich
-pyyaml
-jinja2
-requests
-
-# Development dependencies (optional)
-# Uncomment to install locally for development
-# flake8==7.0.0
-# black==24.4.2
-# isort==5.13.2
+crewai[tools]>=0.80,<1.0
+playwright>=1.40,<2.0
+pytest>=7.0,<9.0
+pytest-html>=4.0,<5.0
+pytest-json-report>=1.5,<2.0
+pytest-xdist>=3.0,<4.0
+python-dotenv>=1.0,<2.0
+rich>=13.0,<14.0
+pyyaml>=6.0,<7.0
+jinja2>=3.1,<4.0
+requests>=2.31,<3.0


### PR DESCRIPTION
## Summary

All runtime dependencies in requirements.txt were unpinned, which means builds can break at any time when upstream packages release breaking changes.

## Changes
- Added version constraints using compatible release constraints (>=X.Y,<X+1)
- Created requirements-dev.txt for development dependencies
- Allows patch updates while preventing breaking major changes
- Dependabot (already configured) will submit PRs for version bumps

## Testing
pip install -r requirements.txt
pytest --co

## Related Issue
Fixes #20