### PR TITLE
feat: expose OpenAI model as configurable action input (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ area: <feature_area>
 
 | Input               | Required | Default          | Description                                       |
 | ------------------- | -------- | ---------------- | ------------------------------------------------- |
-| `openai-api-key`    | **Yes**  | —                | OpenAI API key                                    |
+| `openai-api-key`    | **Yes**  | —                | OpenAI API key
+
+| `openai-model` | No | `openai/gpt-4.1` | OpenAI model for test generation (e.g., openai/gpt-4.1, openai/gpt-4o) |                                   |
 | `staging-url`       | **Yes**  | —                | Staging environment URL                           |
 | `qa-github-token`   | No       | `github.token`   | GitHub token (for private repo access)             |
 | `staging-email`     | No       | `test@example.com` | Test account email                              |

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,12 @@ inputs:
   openai-api-key:
     description: 'OpenAI API key for test generation'
     required: true
-  
+
+  openai-model:
+    description: 'OpenAI model to use for test generation (e.g., openai/gpt-4.1, openai/gpt-4o, openai/gpt-3.5-turbo)'
+    required: false
+    default: 'openai/gpt-4.1'
+
   qa-github-token:
     description: 'GitHub token with access to AutoQA repository (required for private repos)'
     required: false
@@ -230,6 +235,7 @@ runs:
         # Core configuration
         GITHUB_TOKEN: ${{ github.token }}
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+        OPENAI_MODEL_NAME: ${{ inputs.openai-model }}
         STAGING_URL: ${{ inputs.staging-url }}
         STAGING_EMAIL: ${{ inputs.staging-email }}
         STAGING_PASSWORD: ${{ inputs.staging-password }}

--- a/docs/ACTION_USAGE.md
+++ b/docs/ACTION_USAGE.md
@@ -355,6 +355,20 @@ To use this action, your repository needs:
 - 🔒 Tests only run against staging environments
 
 ---
+### Model Selection
+
+By default, AutoQA uses `openai/gpt-4.1` for test generation. You can override this with the `openai-model` input:
+
+```yaml
+- name: Generate and Execute Tests
+  uses: AISquare-Studio/AISquare-Studio-QA@main
+  with:
+    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+    openai-model: 'openai/gpt-4o'
+    staging-url: ${{ secrets.STAGING_URL }}
+```
+
+Supported models include any OpenAI chat model accessible via your API key, such as `openai/gpt-4.1`, `openai/gpt-4o`, or `openai/gpt-3.5-turbo`.
 
 **🎉 You're ready to use AISquare Studio AutoQA in your repository!**
 


### PR DESCRIPTION
Closes #22

## What changed
- Added `openai-model` input to `action.yml` with default `openai/gpt-4.1`
- Wired the input to `OPENAI_MODEL_NAME` environment variable in the action's run step
- Updated the Action Inputs table in `README.md`
- Added a "Model Selection" section to `docs/ACTION_USAGE.md`

## How to test
Use the new input in a workflow:
```yaml
- uses: AISquare-Studio/AISquare-Studio-QA@main
  with:
    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
    openai-model: 'openai/gpt-4o'
    staging-url: ${{ secrets.STAGING_URL }}
```

Default behavior is unchanged — still uses `openai/gpt-4.1` when not specified.