### PR TITLE
fix(ci): pin playwright==1.54.0, remove wildcard browser-cache restore-keys, guard self-test on fork/Dependabot PRs

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,17 +23,17 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements.txt'
       
-      # Cache Playwright browsers to speed up test runs (saves ~2-3 minutes)
+      # Cache Playwright browsers to speed up test runs (saves ~2-3 minutes).
+      # Exact-match key only — see action.yml: a wildcard restore-key returns a
+      # browser dir for the wrong Playwright version while still reporting
+      # cache-hit == 'true', which skips the install and breaks browser launch.
       - name: 🎭 Cache Playwright Browsers
         uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('requirements.txt') }}-v1
-          restore-keys: |
-            ${{ runner.os }}-playwright-v1
-            ${{ runner.os }}-playwright-
-      
+          key: ${{ runner.os }}-playwright-${{ hashFiles('requirements.txt') }}-v3
+
       - name: 📦 Install Dependencies
         run: |
           pip install -r requirements.txt
@@ -87,8 +87,15 @@ jobs:
   test-self-autoqa:
     name: 🚀 Test Self AutoQA
     runs-on: ubuntu-latest
-    # if: contains(github.event.pull_request.body, 'AutoQA') || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
-    
+    # This job needs OPENAI_API_KEY / STAGING_URL / STAGING_EMAIL / STAGING_PASSWORD.
+    # GitHub does not expose repository secrets to pull_request runs from a fork, nor
+    # to Dependabot-authored PRs, so the job could only ever fail there (e.g. #43).
+    # Skip it in exactly those two cases; push and workflow_dispatch are unaffected.
+    # Do NOT "fix" this by switching the trigger to pull_request_target — this repo
+    # is PUBLIC with forks, and pull_request_target would run fork code with those
+    # secrets in scope. A skipped job is the correct outcome, not a workaround.
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' && github.actor != 'dependabot[bot]') }}
+
     steps:
       - name: 📋 Checkout Code
         uses: actions/checkout@v6
@@ -96,17 +103,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      # Cache Playwright browsers for the action test
+      # Cache Playwright browsers for the action test — exact-match key only.
+      # Note this job shares ~/.cache/ms-playwright with the composite action's own
+      # cache step, so a wildcard restore-key here could poison that path too.
       - name: 🎭 Cache Playwright Browsers (for Action)
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-action-${{ hashFiles('requirements.txt') }}-v1
-          restore-keys: |
-            ${{ runner.os }}-playwright-action-v1
-            ${{ runner.os }}-playwright-v1
-            ${{ runner.os }}-playwright-
-      
+          key: ${{ runner.os }}-playwright-action-${{ hashFiles('requirements.txt') }}-v3
+
       - name: 🤖 Test AutoQA Action (Self)
         uses: ./
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,16 +23,14 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements.txt'
       
-      # Cache Playwright browsers to speed up test runs (saves ~2-3 minutes).
-      # Exact-match key only — see action.yml: a wildcard restore-key returns a
-      # browser dir for the wrong Playwright version while still reporting
-      # cache-hit == 'true', which skips the install and breaks browser launch.
+      # Exact-match key only, and one canonical key shared by every step that
+      # touches ~/.cache/ms-playwright. Rationale in action.yml.
       - name: 🎭 Cache Playwright Browsers
         uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('requirements.txt') }}-v3
+          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('requirements.txt') }}-v3
 
       - name: 📦 Install Dependencies
         run: |
@@ -51,6 +49,25 @@ jobs:
         run: |
           playwright install-deps chromium
       
+      # Asserts the pip package and the cached browser build actually agree, which
+      # is the exact failure this workflow's cache fix addresses. It lives in THIS
+      # job on purpose: no secrets are required, so unlike `test-self-autoqa` it
+      # still runs on fork and Dependabot PRs — and a Dependabot bump of the
+      # `playwright==` pin is precisely the change that must not merge unvalidated.
+      - name: "🎭 Smoke: chromium actually launches"
+        run: |
+          python -c "
+          from importlib.metadata import version
+          from playwright.sync_api import sync_playwright
+          with sync_playwright() as p:
+              b = p.chromium.launch()
+              page = b.new_page()
+              page.set_content('<h1 data-testid=ok>ok</h1>')
+              assert page.inner_text('[data-testid=ok]') == 'ok'
+              b.close()
+          print('✅ chromium launched under playwright ' + version('playwright'))
+          "
+
       - name: 🔍 Test AutoQA Parser
         run: |
           python -c "
@@ -103,14 +120,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      # Cache Playwright browsers for the action test — exact-match key only.
-      # Note this job shares ~/.cache/ms-playwright with the composite action's own
-      # cache step, so a wildcard restore-key here could poison that path too.
+      # Same canonical key as the other two steps: all three mount the identical
+      # path, and requirements.txt / .autoqa-action/requirements.txt are the same
+      # file, so a shared key lets them reuse one warm cache instead of paying
+      # three separate ~100MB misses. Rationale in action.yml.
       - name: 🎭 Cache Playwright Browsers (for Action)
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-action-${{ hashFiles('requirements.txt') }}-v3
+          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('requirements.txt') }}-v3
 
       - name: 🤖 Test AutoQA Action (Self)
         uses: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - unreleased
+
+> Not yet tagged. `release.yml` fires on `v*.*.*` tags only, and its final step
+> runs `git tag -fa v0 && git push origin v0 --force` — the `v0` major tag is
+> force-moved to whatever was tagged last. Consumers who want the current
+> behaviour should pin `AISquare-Studio/AISquare-Studio-QA@v0`, which always
+> resolves to the newest 0.x release; pin `@v0.3.0` only to freeze.
+
+### Fixed
+
+- **Playwright browser launch failures (`BrowserType.launch: Executable doesn't exist`).**
+  `requirements.txt` declared a bare, unversioned `playwright`, so the pip package
+  floated to whatever was newest on the runner while the cached browser build in
+  `~/.cache/ms-playwright` could be arbitrarily older. Pinned `playwright==1.54.0`,
+  the version the code is developed against (only `playwright.sync_api` symbols are
+  used: `sync_playwright`, `Page`, `TimeoutError`).
+- **Stale Playwright browser cache silently satisfying the cache check.** The
+  browser cache in `action.yml` was keyed on `hashFiles('.autoqa-action/requirements.txt')`
+  — a constant, because nothing in that file was pinned — and carried the wildcard
+  restore-key `${{ runner.os }}-playwright-`. Any prior cache entry from any
+  Playwright version would restore, `steps.playwright-cache.outputs.cache-hit`
+  would report `true`, and the `playwright install chromium` step (guarded by
+  `if: cache-hit != 'true'`) would be skipped — leaving no browser binary on disk.
+  Removed all restore-keys (exact-match only) and rotated the key suffix to `-v3`
+  to invalidate every poisoned entry. Applied the same fix to both Playwright
+  cache steps in `.github/workflows/test-action.yml`, which share the same path.
+- **`test-self-autoqa` failing on every fork and Dependabot PR.** The job consumes
+  `OPENAI_API_KEY`, `STAGING_URL`, `STAGING_EMAIL` and `STAGING_PASSWORD`, which
+  GitHub deliberately withholds from fork PRs and from Dependabot, so the job could
+  only ever go red there (e.g. #43). Added a job-level guard that skips it for
+  fork-originated and Dependabot PRs while leaving `push` and `workflow_dispatch`
+  runs untouched. The trigger stays `pull_request`: this repository is public with
+  forks, and `pull_request_target` would execute fork-controlled code with those
+  secrets in scope.
+
 ## [0.2.0] - 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate and Execute Tests
-        uses: AISquare-Studio/AISquare-Studio-QA@main
+        uses: AISquare-Studio/AISquare-Studio-QA@v0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           staging-url: ${{ secrets.STAGING_URL }}

--- a/action.yml
+++ b/action.yml
@@ -190,17 +190,34 @@ runs:
         cache-dependency-path: '.autoqa-action/requirements.txt'
     
     # Cache Playwright browsers to avoid downloading ~100MB each run.
-    # NO restore-keys: a partial-key restore hands back a browser directory built
+    #
+    # THE CANONICAL EXPLANATION for the BROWSER cache — the two cache steps in
+    # .github/workflows/test-action.yml point here rather than repeating it.
+    # (The repo-clone cache above still carries a restore-key; it is a different
+    # shape and is tracked separately, because no cache-hit-gated step depends on
+    # it and the checkout that follows overwrites the path unconditionally.)
+    #
+    # NO restore-keys here. A partial-key restore hands back a browser directory built
     # for a different Playwright version, `cache-hit` still reports 'true', the
     # install step below is skipped, and the run dies with
     # "BrowserType.launch: Executable doesn't exist". Exact-match only — a cache
-    # miss costs ~2-3 min, a wrong hit costs a red run and a bogus QA verdict.
+    # miss costs ~2-3 min, a wrong hit costs a red run and a bogus QA verdict,
+    # which is strictly worse for a tool whose entire output is a verdict.
+    #
+    # ONE key shared by all three steps that mount ~/.cache/ms-playwright. The
+    # hashFiles() inputs differ only by location (requirements.txt here is checked
+    # out as .autoqa-action/requirements.txt), so the content hash is identical and
+    # a shared prefix lets them reuse one warm cache. Distinct prefixes bought
+    # nothing and cost an extra cold miss each.
+    #
+    # The pin in requirements.txt is what makes this key able to rotate at all:
+    # with an unpinned `playwright`, hashFiles() is a constant.
     - name: 🎭 Cache Playwright Browsers
       uses: actions/cache@v5
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-autoqa-playwright-${{ hashFiles('.autoqa-action/requirements.txt') }}-v3
+        key: ${{ runner.os }}-ms-playwright-${{ hashFiles('.autoqa-action/requirements.txt') }}-v3
 
     # Install Python dependencies (pip packages cached above)
     - name: 📦 Install AutoQA Dependencies

--- a/action.yml
+++ b/action.yml
@@ -189,18 +189,19 @@ runs:
         cache: 'pip'
         cache-dependency-path: '.autoqa-action/requirements.txt'
     
-    # Cache Playwright browsers to avoid downloading ~100MB each run
+    # Cache Playwright browsers to avoid downloading ~100MB each run.
+    # NO restore-keys: a partial-key restore hands back a browser directory built
+    # for a different Playwright version, `cache-hit` still reports 'true', the
+    # install step below is skipped, and the run dies with
+    # "BrowserType.launch: Executable doesn't exist". Exact-match only — a cache
+    # miss costs ~2-3 min, a wrong hit costs a red run and a bogus QA verdict.
     - name: 🎭 Cache Playwright Browsers
       uses: actions/cache@v5
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-autoqa-playwright-${{ hashFiles('.autoqa-action/requirements.txt') }}-v2
-        restore-keys: |
-          ${{ runner.os }}-autoqa-playwright-v2
-          ${{ runner.os }}-playwright-v2
-          ${{ runner.os }}-playwright-
-    
+        key: ${{ runner.os }}-autoqa-playwright-${{ hashFiles('.autoqa-action/requirements.txt') }}-v3
+
     # Install Python dependencies (pip packages cached above)
     - name: 📦 Install AutoQA Dependencies
       shell: bash

--- a/docs/ACTION_USAGE.md
+++ b/docs/ACTION_USAGE.md
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       
       - name: 🤖 Run AutoQA
-        uses: AISquare-Studio/AISquare-Studio-QA@main
+        uses: AISquare-Studio/AISquare-Studio-QA@v0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           qa-github-token: ${{ secrets.QA_GITHUB_TOKEN }}
@@ -200,7 +200,7 @@ The action provides these outputs for use in subsequent steps:
 ```yaml
 - name: 🤖 Run AutoQA
   id: autoqa
-  uses: AISquare-Studio/AISquare-Studio-QA@main
+  uses: AISquare-Studio/AISquare-Studio-QA@v0
   # ... inputs ...
 
 - name: 📊 Check Results
@@ -222,7 +222,7 @@ Customize action behavior with additional inputs:
 
 ```yaml
 - name: 🤖 Run AutoQA (Advanced)
-  uses: AISquare-Studio/AISquare-Studio-QA@main
+  uses: AISquare-Studio/AISquare-Studio-QA@v0
   with:
     # Required secrets
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -361,7 +361,7 @@ By default, AutoQA uses `openai/gpt-4.1` for test generation. You can override t
 
 ```yaml
 - name: Generate and Execute Tests
-  uses: AISquare-Studio/AISquare-Studio-QA@main
+  uses: AISquare-Studio/AISquare-Studio-QA@v0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     openai-model: 'openai/gpt-4o'

--- a/docs/COMPLETE_AUTOMATION_QA_OVERVIEW.md
+++ b/docs/COMPLETE_AUTOMATION_QA_OVERVIEW.md
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AISquare-Studio/AISquare-Studio-QA@main
+      - uses: AISquare-Studio/AISquare-Studio-QA@v0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           staging-url: ${{ secrets.STAGING_URL }}

--- a/docs/DASHBOARD_JSON_SCHEMA.md
+++ b/docs/DASHBOARD_JSON_SCHEMA.md
@@ -43,7 +43,7 @@ The payload has **three top-level keys**:
 ```yaml
 - name: 🤖 Run AutoQA
   id: autoqa
-  uses: AISquare-Studio/AISquare-Studio-QA@main
+  uses: AISquare-Studio/AISquare-Studio-QA@v0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     staging-url: ${{ secrets.STAGING_URL }}

--- a/docs/FE_REACT_INTEGRATION.md
+++ b/docs/FE_REACT_INTEGRATION.md
@@ -176,7 +176,7 @@ The JSON has **three top-level sections**:
 ```yaml
 - name: 🤖 Run AutoQA
   id: autoqa
-  uses: AISquare-Studio/AISquare-Studio-QA@main
+  uses: AISquare-Studio/AISquare-Studio-QA@v0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     staging-url: ${{ secrets.STAGING_URL }}
@@ -368,7 +368,7 @@ Set `execution-mode: gap-driven` in your workflow:
 
 ```yaml
 - name: 🤖 Generate Tests for Uncovered Modules
-  uses: AISquare-Studio/AISquare-Studio-QA@main
+  uses: AISquare-Studio/AISquare-Studio-QA@v0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     staging-url: ${{ secrets.STAGING_URL }}

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -19,6 +19,13 @@ Each release creates two types of tags:
 | Full version | `v1.2.3` | Immutable, pinned release |
 | Major version | `v1` | Floating tag, always points to latest `v1.x.x` |
 
+> **This repository is still on 0.x, so the live major tag is `v0`, not `v1`.** The
+> `v1` examples below illustrate the scheme; copy them with `v0` until 1.0.0 ships.
+> Every doc in this repo now pins `@v0` for exactly this reason — see `README.md`
+> and `docs/ACTION_USAGE.md`. Note also that the release job force-moves the major
+> tag (`git tag -fa v0 && git push origin v0 --force`), so `@v0` retargets on every
+> 0.x release; pin a full version to freeze.
+
 Users reference the action by major version for automatic minor/patch updates:
 
 ```yaml

--- a/docs/SINGLE_COMMENT_FIX.md
+++ b/docs/SINGLE_COMMENT_FIX.md
@@ -214,7 +214,7 @@ For backward compatibility with existing comments:
 
 This fix is **automatically applied** when using:
 ```yaml
-uses: AISquare-Studio/AISquare-Studio-QA@main
+uses: AISquare-Studio/AISquare-Studio-QA@v0
 ```
 
 ### For Users with Custom Workflows:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
 crewai[tools]
-playwright
+# Pinned: the Playwright pip package and its browser build are version-locked to
+# each other. An unpinned `playwright` also makes hashFiles(requirements.txt) a
+# constant, so the browser cache key in action.yml never rotates and a stale
+# ~/.cache/ms-playwright can be restored for a newer pip package —
+# producing "BrowserType.launch: Executable doesn't exist".
+playwright==1.54.0
 pytest
 pytest-html
 pytest-json-report

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,12 @@ crewai[tools]
 # constant, so the browser cache key in action.yml never rotates and a stale
 # ~/.cache/ms-playwright can be restored for a newer pip package —
 # producing "BrowserType.launch: Executable doesn't exist".
+#
+# UPGRADE CADENCE: bump deliberately, not never — 1.54.0 is several minors behind
+# upstream and a pin left alone just relocates the staleness it was meant to fix.
+# Dependabot raises the bump; the `🎭 Smoke: chromium actually launches` step in
+# test-action.yml validates it without needing secrets, so a bump is safe to merge
+# on a green PR even though `test-self-autoqa` skips for Dependabot.
 playwright==1.54.0
 pytest
 pytest-html


### PR DESCRIPTION
Three CI/runtime defects in the AutoQA action, each fixed at its root rather than worked around. Groundwork for #60 (wire AutoQA to stable flows on v3, unified, explainability) — the T2 blockers that remain are filed as #61 and #62 and are explicitly **not** touched here.

Branched from `origin/main` at `8e2c724`, so #40 (configurable `openai-model`), #42 and #43 are all preserved — `action.yml` keeps `openai-model` at lines 14 and 238.

---

## 1. `BrowserType.launch: Executable doesn't exist` — root cause

Two independent faults compounded:

**a. `requirements.txt:2` declared a bare `playwright`.** The pip package floated to whatever was newest on the runner. The Playwright pip package and its browser build under `~/.cache/ms-playwright` are version-locked to each other, so a floating package plus a fixed cache is a guaranteed eventual mismatch. Pinned `playwright==1.54.0` — verified to exist on PyPI (`pip index versions playwright` lists 1.54.0; latest is 1.62.0) and verified to be the version the working dev environment actually has installed. The code only touches the stable sync API — `sync_playwright`, `Page`, `TimeoutError` from `playwright.sync_api` — so there is no 1.5x feature dependency pushing us higher.

**b. `action.yml:198-202` — the wildcard restore-key was the actual defect.**

```yaml
key: ${{ runner.os }}-autoqa-playwright-${{ hashFiles('.autoqa-action/requirements.txt') }}-v2
restore-keys: |
  ${{ runner.os }}-autoqa-playwright-v2
  ${{ runner.os }}-playwright-v2
  ${{ runner.os }}-playwright-      # <-- matches any Playwright cache ever written
```

The key was keyed on `hashFiles(requirements.txt)`, which **never changed** because nothing in that file was pinned — so the key never rotated even as the installed browser version moved. Worse, the trailing `${{ runner.os }}-playwright-` prefix matches *any* Playwright cache entry from *any* version or workflow.

The failure sequence: a stale browser directory restores via the wildcard → `actions/cache` sets `steps.playwright-cache.outputs.cache-hit` to `'true'` on a **partial** restore → the install step at `action.yml:207-213`, guarded by `if: steps.playwright-cache.outputs.cache-hit != 'true'`, is **skipped** → the "cached browsers" branch at `action.yml:216-222` runs only `playwright install-deps chromium`, which installs OS libraries and no browser → launch fails.

Fix: deleted all three restore-keys (exact-match only) and rotated the suffix to `-v3` to invalidate every already-poisoned entry. A cache miss costs 2-3 minutes; a wrong hit costs a red run and, worse, an unreliable QA verdict. The same two-cache-step pattern in `.github/workflows/test-action.yml` (lines 32-35 and 111-115 pre-change) had the identical wildcard and shares the same `~/.cache/ms-playwright` path, so it is fixed the same way — leaving it would let this workflow re-poison the cache the action reads.

## 2. This repo's own red CI

`test-self-autoqa` consumes `OPENAI_API_KEY`, `STAGING_URL`, `STAGING_EMAIL`, `STAGING_PASSWORD`. GitHub deliberately withholds repository secrets from fork-originated `pull_request` runs and from Dependabot, so the job could only ever go red there — which is why #43 and every future dependency bump shows a failure that says nothing about the change. Added a job-level guard matching the shape of closed PR #44:

```yaml
if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' && github.actor != 'dependabot[bot]') }}
```

The leading `github.event_name != 'pull_request'` disjunct is load-bearing: on `push` and `workflow_dispatch` the `github.event.pull_request.*` context is empty, so a guard written only as the head-repo comparison would silently disable the self-test on `main` pushes too. Both `pull_request.user.login` and `github.actor` are checked so the skip holds whether Dependabot opened the PR or merely triggered the run.

### Why NOT `pull_request_target`

`pull_request_target` is the usual reflex here and it is the wrong answer for this repository. This repo is **public** (`visibility: public`) with **10 forks**, and it holds those four secrets. `pull_request_target` runs in the context of the base repository *with secrets available*, while the workflow can be induced to check out and execute fork-controlled code — here that means arbitrary fork content reaching a job that has `OPENAI_API_KEY` and live staging credentials in scope. A skipped job on fork PRs is the correct, honest outcome; exfiltrating credentials to save a green tick is not a trade worth making.

## 3. CHANGELOG

Added a `0.3.0` entry describing all three fixes. **Deliberately not tagged** — cutting the release is the maintainer's call.

Note for consumers: `release.yml` ends with `git tag -fa "$MAJOR" -m ... && git push origin "$MAJOR" --force`, so the `v0` tag is **force-moved** onto whatever was tagged last. Pin `AISquare-Studio/AISquare-Studio-QA@v0` to track the newest 0.x automatically; pin `@v0.3.0` only to freeze.

---

## Scope boundaries — read before merging

**This PR does not make anything a required status check.** No ruleset is touched, no `required_status_checks` are added. `required_status_checks` currently exists in zero rulesets across the org, and that stays true after this merge. Making `test-action.yml` required is a separate, later decision.

**The `autoQA.yml` body-keyword `if:` removal is a deliberate, separate follow-up.** The ordering is not cosmetic — it is a correctness constraint. GitHub counts a check run with `conclusion=skipped` as **satisfying** a required status check, and a job-level `if:` that evaluates false still publishes its check run. So requiring a conditionally-skipped check produces a permanently-green gate: strictly worse than an honest red, because it looks like coverage and is not. The only safe order is: (1) remove the conditional `if:` so the job always runs, (2) confirm real `success`/`failure` conclusions across ≥20 PRs, (3) *then* require it. Doing step 3 first, or bundling it here, would manufacture exactly the false-green this PR is trying to eliminate.

That same reasoning applies to the guard added in change 2 — which is why it must stay unrequired. Its whole purpose is to skip, and a skip that satisfies a required check is a lie. Guard first, require never (or only after the job is unconditional for in-repo PRs).

## Follow-ups filed, not fixed

The two entry-point blockers for #60, both filed as issues so they can be scheduled rather than smuggled into a CI fix:

- **#61 — AutoQA hardcodes `/login`.** No `login-path` or `auth-mode` input exists; the URL is built as `f"{base_url}/login"` at `src/crews/qa_crew.py:82`, `src/autoqa/action_runner.py:787` and `:869`, `src/autoqa/cross_repo_manager.py:236`, and the path is additionally baked into agent prompt text at `src/agents/planner_agent.py:48,60-61,72-73` and `src/agents/step_executor_agent.py:440,443`. `grep -rniE "skip_login|auth_mode|anonymous|requires_login" src/ config/ action.yml` returns zero lines. This hard-blocks `AISquare-AIStudio-v3`, whose route table is four entries with no `/login` (`src/App.tsx:78-81`).
- **#62 — flow inventory and selector map load from *this* repo.** `src/crews/qa_crew.py:61` resolves `config/test_data.yaml` via `Path(__file__).parent.parent.parent`, i.e. always inside the checked-out action, with no override. So onboarding a surface means publishing its flow inventory and selector map to a public repo. `config/testid_registry.yaml` also declares three fictional flows (`login`/`signup`/`dashboard`, 14 test IDs) that match nothing on any target surface — the mechanical reason gap analysis reports 0 modules / 0.0% coverage while still concluding `SUCCESS`.

Also relevant: this **partially addresses #20** (pin dependency versions) but does not close it. Only `playwright` is pinned, and only because it is the direct cause of the browser failure. The other ten entries in `requirements.txt` — including the bare `crewai[tools]`, which floats a large and fast-moving dependency tree — remain unpinned. #20 should stay open.

## Verification

```
python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in ['action.yml','.github/workflows/test-action.yml']]"
```

Both parse. Post-parse assertions: `action.yml` still exposes 19 inputs including `openai-model`; the Playwright cache step's `with:` now has keys `['path','key']` only, no `restore-keys`; `test-action.yml` still defines all three jobs (`test-action-components`, `test-self-autoqa`, `validate-action-yml`). Changes are confined to YAML, `requirements.txt` and Markdown, so `lint.yml` (black/isort/flake8 over Python) is unaffected.

The cache fix cannot be fully proven without a live run: the observable proof is that the next run on this branch shows `cache-hit` false and executes `🎭 Install Playwright Browsers` rather than skipping to `install-deps` alone. Worth watching on the first CI run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
