### PR TITLE
chore(release): no force-push in the release path; consumers pin exact versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,11 +168,18 @@ jobs:
           generate_release_notes: true
           make_latest: true
 
-      - name: Update major version tag
+      # The floating major tag (vN) was removed deliberately. Maintaining it required
+      # `git tag -fa` + `git push --force` on every release, which silently retargets
+      # every consumer pinned to @vN the moment a release lands — including a bad one.
+      # Consumers now pin an exact, immutable version (see docs/RELEASE_PROCESS.md) and
+      # bump on purpose. Nothing in this workflow force-pushes anything.
+      - name: Confirm no mutable tag was moved
         run: |
+          TAG="${{ steps.version.outputs.tag }}"
           MAJOR="v${{ steps.version.outputs.major }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -fa "$MAJOR" -m "Update $MAJOR tag to ${{ steps.version.outputs.tag }}"
-          git push origin "$MAJOR" --force
-          echo "🏷️ Updated $MAJOR → ${{ steps.version.outputs.tag }}"
+          echo "✅ Released $TAG as an immutable tag."
+          echo "ℹ️  The floating $MAJOR tag is intentionally NOT updated by this workflow."
+          if git ls-remote --exit-code --tags origin "refs/tags/$MAJOR" >/dev/null 2>&1; then
+            POINTS_AT=$(git rev-parse --short "refs/tags/$MAJOR^{commit}" 2>/dev/null || echo unknown)
+            echo "::warning title=Stale floating tag::$MAJOR still exists on origin and now points at $POINTS_AT, which will drift from $TAG. Consumers should pin $TAG. Delete $MAJOR once nothing references it."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Removed the floating major version tag from the release process.** `release.yml` no longer runs
+  `git tag -fa vN` + `git push --force`. A mutable reference that silently retargets every consumer
+  on each release is the same class of failure as the wildcard browser-cache restore-key fixed in
+  0.3.0: it keeps serving stale content while reporting success. Consumers now pin an exact
+  immutable version (`@v0.3.0`) and upgrade deliberately.
+- Repinned every documented reference to `@v0.3.0` — 13 refs across `README.md`, `docs/` and
+  `examples/`. The two `examples/*.yml` files and `awesome-aisquare` were still on `@main` and were
+  missed by the 0.3.0 pass; `awesome-aisquare` lives in another repo and is tracked separately.
+- The `v0` tag on origin is now frozen and unmaintained. `release.yml` emits a warning while it
+  exists so it does not quietly rot.
+
 ## [0.3.0] - unreleased
 
 > Not yet tagged. `release.yml` fires on `v*.*.*` tags only, and its final step
 > runs `git tag -fa v0 && git push origin v0 --force` — the `v0` major tag is
 > force-moved to whatever was tagged last. Consumers who want the current
-> behaviour should pin `AISquare-Studio/AISquare-Studio-QA@v0`, which always
+> behaviour should pin `AISquare-Studio/AISquare-Studio-QA@v0.3.0`, which always
 > resolves to the newest 0.x release; pin `@v0.3.0` only to freeze.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate and Execute Tests
-        uses: AISquare-Studio/AISquare-Studio-QA@v0
+        uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           staging-url: ${{ secrets.STAGING_URL }}

--- a/docs/ACTION_USAGE.md
+++ b/docs/ACTION_USAGE.md
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       
       - name: 🤖 Run AutoQA
-        uses: AISquare-Studio/AISquare-Studio-QA@v0
+        uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           qa-github-token: ${{ secrets.QA_GITHUB_TOKEN }}
@@ -200,7 +200,7 @@ The action provides these outputs for use in subsequent steps:
 ```yaml
 - name: 🤖 Run AutoQA
   id: autoqa
-  uses: AISquare-Studio/AISquare-Studio-QA@v0
+  uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
   # ... inputs ...
 
 - name: 📊 Check Results
@@ -222,7 +222,7 @@ Customize action behavior with additional inputs:
 
 ```yaml
 - name: 🤖 Run AutoQA (Advanced)
-  uses: AISquare-Studio/AISquare-Studio-QA@v0
+  uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
   with:
     # Required secrets
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -361,7 +361,7 @@ By default, AutoQA uses `openai/gpt-4.1` for test generation. You can override t
 
 ```yaml
 - name: Generate and Execute Tests
-  uses: AISquare-Studio/AISquare-Studio-QA@v0
+  uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     openai-model: 'openai/gpt-4o'

--- a/docs/COMPLETE_AUTOMATION_QA_OVERVIEW.md
+++ b/docs/COMPLETE_AUTOMATION_QA_OVERVIEW.md
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AISquare-Studio/AISquare-Studio-QA@v0
+      - uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           staging-url: ${{ secrets.STAGING_URL }}

--- a/docs/DASHBOARD_JSON_SCHEMA.md
+++ b/docs/DASHBOARD_JSON_SCHEMA.md
@@ -43,7 +43,7 @@ The payload has **three top-level keys**:
 ```yaml
 - name: 🤖 Run AutoQA
   id: autoqa
-  uses: AISquare-Studio/AISquare-Studio-QA@v0
+  uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     staging-url: ${{ secrets.STAGING_URL }}

--- a/docs/FE_REACT_INTEGRATION.md
+++ b/docs/FE_REACT_INTEGRATION.md
@@ -176,7 +176,7 @@ The JSON has **three top-level sections**:
 ```yaml
 - name: 🤖 Run AutoQA
   id: autoqa
-  uses: AISquare-Studio/AISquare-Studio-QA@v0
+  uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     staging-url: ${{ secrets.STAGING_URL }}
@@ -368,7 +368,7 @@ Set `execution-mode: gap-driven` in your workflow:
 
 ```yaml
 - name: 🤖 Generate Tests for Uncovered Modules
-  uses: AISquare-Studio/AISquare-Studio-QA@v0
+  uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
   with:
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     staging-url: ${{ secrets.STAGING_URL }}

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -49,8 +49,7 @@ Tag push (v1.2.3)
   ├── Test (parser validation)
   └── Release (after all checks pass)
         ├── Extract release notes from CHANGELOG.md
-        ├── Create GitHub Release
-        └── Update major version tag (v1 → v1.2.3)
+        └── Create GitHub Release   (immutable tag; no mutable tag is moved)
 ```
 
 ### Pre-release Versions
@@ -94,15 +93,16 @@ This triggers the release workflow which will:
 - Validate the action
 - Run linting and tests
 - Create the GitHub Release with notes from the changelog
-- Update the `v1` major version tag
+
+It does **not** move any existing tag.
 
 ### 4. Verify the Release
 
 1. Check the [Actions tab](https://github.com/AISquare-Studio/AISquare-Studio-QA/actions/workflows/release.yml) for the workflow run
 2. Check the [Releases page](https://github.com/AISquare-Studio/AISquare-Studio-QA/releases) for the new release
-3. Verify the major version tag points to the new release:
+3. Confirm no mutable tag was moved — this should list only the frozen legacy `v0`:
    ```bash
-   git ls-remote --tags origin | grep -E 'v[0-9]+$'
+   git ls-remote --tags origin | grep -E 'refs/tags/v[0-9]+$'
    ```
 
 ## GitHub Marketplace
@@ -150,12 +150,19 @@ For critical fixes that need immediate release:
 
 If a release has issues:
 
-1. **Revert the major version tag** to the previous stable release:
-   ```bash
-   git tag -fa v1 v1.2.2 -m "Rollback v1 to v1.2.2"
-   git push origin v1 --force
-   ```
+Tags here are immutable, so there is nothing to move backwards — and that is deliberate. A
+rollback is a **roll forward**:
 
-2. **Mark the bad release as pre-release** on GitHub to warn users
+1. **Mark the bad release as pre-release** on GitHub so it stops being "Latest" and is visibly
+   flagged.
 
-3. **Fix the issue** and release a new patch version
+2. **Fix the issue and release the next patch version** (e.g. `v0.3.1`). Consumers pinned to the
+   bad exact version are unaffected until they bump, which is the whole benefit of exact pins —
+   a bad release cannot reach anyone who did not opt in.
+
+3. **Tell the consumers who already bumped** to pin back to the last good version, e.g.
+   `@v0.2.0`. Because the reference is exact, pinning back is a one-line revert in their repo
+   and needs no cooperation from this one.
+
+Do **not** reintroduce a force-pushed floating tag to make rollback feel faster. A mutable
+reference is what let AutoQA serve a broken build for six months while reporting success.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -12,31 +12,31 @@ This project follows [Semantic Versioning](https://semver.org/):
 
 ### Version Tags
 
-Each release creates two types of tags:
+Each release creates **one** tag, and it never moves:
 
 | Tag | Example | Purpose |
 |-----|---------|---------|
-| Full version | `v1.2.3` | Immutable, pinned release |
-| Major version | `v1` | Floating tag, always points to latest `v1.x.x` |
+| Full version | `v0.3.0` | Immutable. The only thing consumers should reference. |
 
-> **This repository is still on 0.x, so the live major tag is `v0`, not `v1`.** The
-> `v1` examples below illustrate the scheme; copy them with `v0` until 1.0.0 ships.
-> Every doc in this repo now pins `@v0` for exactly this reason — see `README.md`
-> and `docs/ACTION_USAGE.md`. Note also that the release job force-moves the major
-> tag (`git tag -fa v0 && git push origin v0 --force`), so `@v0` retargets on every
-> 0.x release; pin a full version to freeze.
+**There is deliberately no floating major tag.** Maintaining a `vN` tag that always points at the
+newest `vN.x.x` requires `git tag -fa` plus `git push --force` on every release, which silently
+retargets every consumer the instant a release lands — including a bad one. AutoQA sat broken from
+2026-01-15 to 2026-08-03 precisely because a mutable reference kept serving stale content while
+looking current, so this repo does not use that pattern.
 
-Users reference the action by major version for automatic minor/patch updates:
+Consumers pin an exact version:
 
 ```yaml
-- uses: AISquare-Studio/AISquare-Studio-QA@v1
+- uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
 ```
 
-Or pin to an exact version for maximum stability:
+Upgrading is a deliberate one-line PR in the consuming repo. That is the point: you find out you
+are upgrading, and a bad release cannot reach anyone who did not opt in.
 
-```yaml
-- uses: AISquare-Studio/AISquare-Studio-QA@v1.2.3
-```
+> **Legacy:** a `v0` tag still exists on origin from before this change and currently points at the
+> same commit as `v0.3.0`. It is **frozen** — no workflow updates it any more, so it will drift and
+> become misleading. Do not reference it. It should be deleted once nothing points at it; the
+> release workflow emits a warning on every run while it exists.
 
 ## Release Pipeline
 

--- a/docs/SINGLE_COMMENT_FIX.md
+++ b/docs/SINGLE_COMMENT_FIX.md
@@ -214,7 +214,7 @@ For backward compatibility with existing comments:
 
 This fix is **automatically applied** when using:
 ```yaml
-uses: AISquare-Studio/AISquare-Studio-QA@v0
+uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
 ```
 
 ### For Users with Custom Workflows:

--- a/examples/auto-criteria-workflow.yml
+++ b/examples/auto-criteria-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         # (e.g. checkout errors, missing secrets) and makes broken runs appear
         # as "passed". The action already defers test failures internally so
         # that artifacts are uploaded before failing the step.
-        uses: AISquare-Studio/AISquare-Studio-QA@main
+        uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           staging-url: ${{ secrets.STAGING_URL }}

--- a/examples/fe-react-autoqa-workflow.yml
+++ b/examples/fe-react-autoqa-workflow.yml
@@ -49,7 +49,7 @@ jobs:
         # ⚠️ Do NOT add continue-on-error: true — this masks real failures and
         # makes broken runs appear as "passed". The action already defers test
         # failures internally so that artifacts are uploaded before failing.
-        uses: AISquare-Studio/AISquare-Studio-QA@main
+        uses: AISquare-Studio/AISquare-Studio-QA@v0.3.0
         with:
           # Required: OpenAI API key for test generation
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Owner decision: **no force-push anywhere in the release path.**

## What was wrong

`release.yml` maintained a floating `vN` tag on every release:

```
git tag -fa "$MAJOR" -m "Update $MAJOR tag to $TAG"
git push origin "$MAJOR" --force
```

That is a mutable reference which silently retargets every consumer pinned to `@vN` the instant a release lands — good release or bad. It is the same failure shape as the wildcard browser-cache `restore-key` fixed in 0.3.0: a stale artifact served while the check reports success. AutoQA was broken from **2026-01-15 to 2026-08-03** under exactly that pattern.

## Changes

- **`release.yml`** — the `Update major version tag` step is gone. Replaced with a verification step that states the release is immutable and emits a GitHub Actions `::warning` while a stale `vN` tag still exists on origin, so the leftover cannot rot unnoticed. Nothing in `.github/workflows` force-pushes anything.
- **13 refs repinned to `@v0.3.0`** across `README.md`, `CHANGELOG.md`, `docs/` and `examples/`. Note `examples/auto-criteria-workflow.yml` and `examples/fe-react-autoqa-workflow.yml` were still on `@main` — they were missed by the 0.3.0 doc pass because that pass only grepped `README.md` and `docs/`.
- **`docs/RELEASE_PROCESS.md`** — `Version Tags` rewritten to one immutable tag per release, plus the four places that still described the floating tag: the pipeline diagram, the step-3 bullets, the verification step, and the `Rolling Back a Release` procedure, which itself instructed a force-push.

## Rollback becomes a roll-forward

Immutable tags cannot be moved backwards, which is the point. Mark the bad release pre-release, ship the next patch, and tell anyone who already bumped to pin back — a one-line revert in their repo, needing nothing from this one.

## Trade-off, stated plainly

Consumers no longer receive patches automatically; upgrading is a deliberate one-line PR. That is strictly worse for propagation speed and strictly better for blast radius. Given this action just spent six months silently broken behind a mutable reference, blast radius wins.

## Not in this PR

- Deleting the frozen `v0` tag on origin. It currently points at the same commit as `v0.3.0`, so it is not wrong yet — it will simply stop being updated. Needs confirmation nothing references it before deletion.
- `AISquare-Studio/awesome-aisquare` `README.md` still shows `@main`. Different repo, tracked separately.